### PR TITLE
Add Go to Declaration handler for Compose resources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,10 +19,11 @@ repositories {
 
 dependencies {
   intellijPlatform {
-    intellijIdea("2025.2.4")
+    intellijIdea("2025.3.2")
     testFramework(TestFrameworkType.Platform)
 
     bundledPlugin("com.intellij.gradle")
+    bundledPlugin("org.jetbrains.kotlin")
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     bundledPlugin("com.intellij.gradle")
     bundledPlugin("org.jetbrains.kotlin")
   }
+
+  testImplementation("junit:junit:4.13.2")
 }
 
 intellijPlatform {

--- a/src/main/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandler.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandler.kt
@@ -1,0 +1,143 @@
+package dev.jordond.composeresourceskit
+
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler
+import com.intellij.ide.highlighter.XmlFileType
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.xml.XmlFile
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
+
+private val RESOURCE_KEY_REGEX = "[a-zA-Z_][a-zA-Z0-9_]*".toRegex()
+private val DRAWABLE_EXTENSIONS = listOf("png", "jpg", "jpeg", "bmp", "webp", "xml", "svg")
+private val FONT_EXTENSIONS = listOf("ttf", "otf")
+
+private sealed interface ResourceReference {
+  val key: String
+
+  data class XmlResource(
+    override val key: String,
+    val xmlTag: String,
+  ) : ResourceReference
+
+  data class FileResource(
+    override val key: String,
+    val dirPrefix: String,
+    val extensions: List<String>,
+  ) : ResourceReference
+}
+
+private val RESOURCE_PREFIXES: List<Pair<String, (String) -> ResourceReference>> = listOf(
+  "Res.string." to { key -> ResourceReference.XmlResource(key, "string") },
+  "Res.array." to { key -> ResourceReference.XmlResource(key, "string-array") },
+  "Res.plurals." to { key -> ResourceReference.XmlResource(key, "plurals") },
+  "Res.drawable." to { key -> ResourceReference.FileResource(key, "drawable", DRAWABLE_EXTENSIONS) },
+  "Res.font." to { key -> ResourceReference.FileResource(key, "font", FONT_EXTENSIONS) },
+)
+
+class ResourceGotoDeclarationHandler : GotoDeclarationHandler {
+  override fun getGotoDeclarationTargets(
+    sourceElement: PsiElement?,
+    offset: Int,
+    editor: Editor,
+  ): Array<PsiElement>? {
+    val project = sourceElement?.project ?: return null
+    val ref = resolveResourceReference(sourceElement) ?: return null
+
+    val targets = when (ref) {
+      is ResourceReference.XmlResource -> findXmlResources(project, ref)
+      is ResourceReference.FileResource -> findFileResources(project, ref)
+    }
+
+    return targets.takeIf { it.isNotEmpty() }?.toTypedArray()
+  }
+
+  override fun getActionText(context: DataContext): String = "Go to Compose Resource"
+
+  private fun resolveResourceReference(element: PsiElement): ResourceReference? {
+    if (element is KtNameReferenceExpression) {
+      val qualified = element.getQualifiedExpressionForSelector()
+      if (qualified != null) return extractResourceReference(qualified)
+    }
+
+    val dotQualified = generateSequence(element) { it.parent }
+      .filterIsInstance<KtDotQualifiedExpression>()
+      .firstOrNull()
+
+    return dotQualified?.let { extractResourceReference(it) }
+  }
+
+  private fun extractResourceReference(expression: KtExpression): ResourceReference? {
+    val text = expression.text
+    return RESOURCE_PREFIXES.firstNotNullOfOrNull { (prefix, factory) ->
+      if (text.startsWith(prefix)) {
+        val key = text.substringAfterLast('.')
+        if (key.isNotEmpty() && key.matches(RESOURCE_KEY_REGEX)) factory(key) else null
+      } else {
+        null
+      }
+    }
+  }
+
+  private fun findXmlResources(
+    project: Project,
+    ref: ResourceReference.XmlResource,
+  ): List<PsiElement> {
+    val psiManager = PsiManager.getInstance(project)
+    return FileTypeIndex
+      .getFiles(XmlFileType.INSTANCE, GlobalSearchScope.projectScope(project))
+      .asSequence()
+      .filter { it.name == "strings.xml" && it.isInComposeResources() }
+      .filter { it.parent?.name?.startsWith("values") == true }
+      .mapNotNull { (psiManager.findFile(it) as? XmlFile)?.rootTag }
+      .flatMap { it.findSubTags(ref.xmlTag).asSequence() }
+      .filter { it.getAttributeValue("name") == ref.key }
+      .map { it.getAttribute("name")?.valueElement ?: it }
+      .toList()
+  }
+
+  private fun findFileResources(
+    project: Project,
+    ref: ResourceReference.FileResource,
+  ): List<PsiElement> {
+    val psiManager = PsiManager.getInstance(project)
+    val scope = GlobalSearchScope.projectScope(project)
+
+    fun VirtualFile.isInResourceDir(): Boolean =
+      isInComposeResources() && parent?.name?.startsWith(ref.dirPrefix) == true
+
+    val xmlMatches = FileTypeIndex
+      .getFiles(XmlFileType.INSTANCE, scope)
+      .asSequence()
+      .filter { it.isInResourceDir() }
+      .filter { it.nameWithoutExtension == ref.key && it.extension in ref.extensions }
+      .mapNotNull { psiManager.findFile(it)?.firstChild }
+
+    val fileMatches = ref.extensions
+      .asSequence()
+      .filter { it != "xml" }
+      .flatMap { ext ->
+        FilenameIndex
+          .getVirtualFilesByName("${ref.key}.$ext", scope)
+          .asSequence()
+          .filter { it.isInResourceDir() }
+          .mapNotNull { psiManager.findFile(it) }
+      }
+
+    return (xmlMatches + fileMatches).toList()
+  }
+
+  private fun VirtualFile.isInComposeResources(): Boolean {
+    val path = this.path
+    return path.contains("/composeResources/") && !path.contains("/build/")
+  }
+}

--- a/src/main/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandler.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandler.kt
@@ -96,7 +96,7 @@ class ResourceGotoDeclarationHandler : GotoDeclarationHandler {
     return FileTypeIndex
       .getFiles(XmlFileType.INSTANCE, GlobalSearchScope.projectScope(project))
       .asSequence()
-      .filter { it.name == "strings.xml" && it.isInComposeResources() }
+      .filter { it.isInComposeResources() }
       .filter { it.parent?.name?.startsWith("values") == true }
       .mapNotNull { (psiManager.findFile(it) as? XmlFile)?.rootTag }
       .flatMap { it.findSubTags(ref.xmlTag).asSequence() }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,8 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.gradle</depends>
+    <depends>com.intellij.modules.xml</depends>
+    <depends>org.jetbrains.kotlin</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <projectConfigurable
@@ -32,5 +34,11 @@
 
         <postStartupActivity
             implementation="dev.jordond.composeresourceskit.ComposeResourcesStartupActivity"/>
+
+        <gotoDeclarationHandler implementation="dev.jordond.composeresourceskit.ResourceGotoDeclarationHandler"/>
+    </extensions>
+
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK2="true" supportsK1="true"/>
     </extensions>
 </idea-plugin>

--- a/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
@@ -5,10 +5,10 @@ import com.intellij.psi.xml.XmlAttributeValue
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
-
   private val handler = ResourceGotoDeclarationHandler()
 
-  private val stringsXml = """
+  private val stringsXml =
+    """
     <?xml version="1.0" encoding="utf-8"?>
     <resources>
         <string name="app_name">My App</string>
@@ -22,9 +22,12 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
             <item quantity="other">%d items</item>
         </plurals>
     </resources>
-  """.trimIndent()
+    """.trimIndent()
 
-  private fun addComposeResource(path: String, content: String) {
+  private fun addComposeResource(
+    path: String,
+    content: String,
+  ) {
     myFixture.addFileToProject("composeResources/$path", content)
   }
 
@@ -81,10 +84,10 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
     addComposeResource(
       "values-fr/strings.xml",
       """
-        <?xml version="1.0" encoding="utf-8"?>
-        <resources>
-            <string name="app_name">Mon App</string>
-        </resources>
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="app_name">Mon App</string>
+      </resources>
       """.trimIndent(),
     )
     val targets = gotoTargets("val x = Res.string.<caret>app_name")
@@ -111,8 +114,8 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
     addComposeResource(
       "drawable/background.xml",
       """
-        <?xml version="1.0" encoding="utf-8"?>
-        <vector xmlns:android="http://schemas.android.com/apk/res/android"/>
+      <?xml version="1.0" encoding="utf-8"?>
+      <vector xmlns:android="http://schemas.android.com/apk/res/android"/>
       """.trimIndent(),
     )
     val targets = gotoTargets("val x = Res.drawable.<caret>background")

--- a/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
@@ -1,0 +1,205 @@
+package dev.jordond.composeresourceskit
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.xml.XmlAttributeValue
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
+
+  private val handler = ResourceGotoDeclarationHandler()
+
+  private val stringsXml = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <resources>
+        <string name="app_name">My App</string>
+        <string name="greeting">Hello World</string>
+        <string-array name="items">
+            <item>One</item>
+            <item>Two</item>
+        </string-array>
+        <plurals name="item_count">
+            <item quantity="one">%d item</item>
+            <item quantity="other">%d items</item>
+        </plurals>
+    </resources>
+  """.trimIndent()
+
+  private fun addComposeResource(path: String, content: String) {
+    myFixture.addFileToProject("composeResources/$path", content)
+  }
+
+  private fun gotoTargets(kotlinCode: String): Array<PsiElement>? {
+    myFixture.configureByText("Test.kt", kotlinCode)
+    val element = myFixture.file.findElementAt(myFixture.caretOffset)
+    return handler.getGotoDeclarationTargets(element, myFixture.caretOffset, myFixture.editor)
+  }
+
+  // region XML resource navigation (string, array, plurals)
+
+  fun testNavigateToStringResource() {
+    addComposeResource("values/strings.xml", stringsXml)
+    val targets = gotoTargets("val x = Res.string.<caret>app_name")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertInstanceOf(targets[0], XmlAttributeValue::class.java)
+    assertEquals("app_name", (targets[0] as XmlAttributeValue).value)
+  }
+
+  fun testNavigateToSecondStringResource() {
+    addComposeResource("values/strings.xml", stringsXml)
+    val targets = gotoTargets("val x = Res.string.<caret>greeting")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertInstanceOf(targets[0], XmlAttributeValue::class.java)
+    assertEquals("greeting", (targets[0] as XmlAttributeValue).value)
+  }
+
+  fun testNavigateToStringArrayResource() {
+    addComposeResource("values/strings.xml", stringsXml)
+    val targets = gotoTargets("val x = Res.array.<caret>items")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertInstanceOf(targets[0], XmlAttributeValue::class.java)
+    assertEquals("items", (targets[0] as XmlAttributeValue).value)
+  }
+
+  fun testNavigateToPluralsResource() {
+    addComposeResource("values/strings.xml", stringsXml)
+    val targets = gotoTargets("val x = Res.plurals.<caret>item_count")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertInstanceOf(targets[0], XmlAttributeValue::class.java)
+    assertEquals("item_count", (targets[0] as XmlAttributeValue).value)
+  }
+
+  fun testStringResourceInMultipleLocales() {
+    addComposeResource("values/strings.xml", stringsXml)
+    addComposeResource(
+      "values-fr/strings.xml",
+      """
+        <?xml version="1.0" encoding="utf-8"?>
+        <resources>
+            <string name="app_name">Mon App</string>
+        </resources>
+      """.trimIndent(),
+    )
+    val targets = gotoTargets("val x = Res.string.<caret>app_name")
+
+    assertNotNull(targets)
+    assertEquals(2, targets!!.size)
+    assertTrue(targets.all { it is XmlAttributeValue })
+  }
+
+  // endregion
+
+  // region File resource navigation (drawable, font)
+
+  fun testNavigateToDrawablePng() {
+    addComposeResource("drawable/icon.png", "fake-png-content")
+    val targets = gotoTargets("val x = Res.drawable.<caret>icon")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertEquals("icon.png", targets[0].containingFile.name)
+  }
+
+  fun testNavigateToDrawableXml() {
+    addComposeResource(
+      "drawable/background.xml",
+      """
+        <?xml version="1.0" encoding="utf-8"?>
+        <vector xmlns:android="http://schemas.android.com/apk/res/android"/>
+      """.trimIndent(),
+    )
+    val targets = gotoTargets("val x = Res.drawable.<caret>background")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertEquals("background.xml", targets[0].containingFile.name)
+  }
+
+  fun testNavigateToFontTtf() {
+    addComposeResource("font/roboto.ttf", "fake-ttf-content")
+    val targets = gotoTargets("val x = Res.font.<caret>roboto")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertEquals("roboto.ttf", targets[0].containingFile.name)
+  }
+
+  fun testNavigateToFontOtf() {
+    addComposeResource("font/opensans.otf", "fake-otf-content")
+    val targets = gotoTargets("val x = Res.font.<caret>opensans")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertEquals("opensans.otf", targets[0].containingFile.name)
+  }
+
+  fun testNavigateToDrawableInQualifiedDirectory() {
+    addComposeResource("drawable-hdpi/icon.png", "fake-png-content")
+    val targets = gotoTargets("val x = Res.drawable.<caret>icon")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertEquals("icon.png", targets[0].containingFile.name)
+  }
+
+  // endregion
+
+  // region Scoping / exclusion
+
+  fun testIgnoresResourcesOutsideComposeResources() {
+    myFixture.addFileToProject("values/strings.xml", stringsXml)
+    val targets = gotoTargets("val x = Res.string.<caret>app_name")
+
+    assertNull(targets)
+  }
+
+  fun testIgnoresResourcesInBuildDirectory() {
+    myFixture.addFileToProject(
+      "build/generated/composeResources/values/strings.xml",
+      stringsXml,
+    )
+    val targets = gotoTargets("val x = Res.string.<caret>app_name")
+
+    assertNull(targets)
+  }
+
+  // endregion
+
+  // region Negative / edge cases
+
+  fun testUnknownResourceTypeReturnsNull() {
+    addComposeResource("values/strings.xml", stringsXml)
+    val targets = gotoTargets("val x = Res.raw.<caret>some_file")
+
+    assertNull(targets)
+  }
+
+  fun testNonResourceExpressionReturnsNull() {
+    val targets = gotoTargets("val x = foo.bar.<caret>baz")
+
+    assertNull(targets)
+  }
+
+  fun testNonExistentResourceReturnsNull() {
+    addComposeResource("values/strings.xml", stringsXml)
+    val targets = gotoTargets("val x = Res.string.<caret>non_existent")
+
+    assertNull(targets)
+  }
+
+  fun testNullSourceElementReturnsNull() {
+    myFixture.configureByText("Test.kt", "val x = 1")
+    val result = handler.getGotoDeclarationTargets(null, 0, myFixture.editor)
+
+    assertNull(result)
+  }
+
+  // endregion
+}

--- a/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
@@ -37,8 +37,6 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
     return handler.getGotoDeclarationTargets(element, myFixture.caretOffset, myFixture.editor)
   }
 
-  // region XML resource navigation (string, array, plurals)
-
   fun testNavigateToStringResource() {
     addComposeResource("values/strings.xml", stringsXml)
     val targets = gotoTargets("val x = Res.string.<caret>app_name")
@@ -97,10 +95,6 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
     assertTrue(targets.all { it is XmlAttributeValue })
   }
 
-  // endregion
-
-  // region File resource navigation (drawable, font)
-
   fun testNavigateToDrawablePng() {
     addComposeResource("drawable/icon.png", "fake-png-content")
     val targets = gotoTargets("val x = Res.drawable.<caret>icon")
@@ -152,10 +146,6 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
     assertEquals("icon.png", targets[0].containingFile.name)
   }
 
-  // endregion
-
-  // region Scoping / exclusion
-
   fun testIgnoresResourcesOutsideComposeResources() {
     myFixture.addFileToProject("values/strings.xml", stringsXml)
     val targets = gotoTargets("val x = Res.string.<caret>app_name")
@@ -172,10 +162,6 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
 
     assertNull(targets)
   }
-
-  // endregion
-
-  // region Negative / edge cases
 
   fun testUnknownResourceTypeReturnsNull() {
     addComposeResource("values/strings.xml", stringsXml)
@@ -204,5 +190,4 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
     assertNull(result)
   }
 
-  // endregion
 }

--- a/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
@@ -189,5 +189,4 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
 
     assertNull(result)
   }
-
 }

--- a/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/ResourceGotoDeclarationHandlerTest.kt
@@ -95,6 +95,48 @@ class ResourceGotoDeclarationHandlerTest : BasePlatformTestCase() {
     assertTrue(targets.all { it is XmlAttributeValue })
   }
 
+  fun testNavigateToStringArrayInSeparateXmlFile() {
+    addComposeResource(
+      "values/arrays.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string-array name="colors">
+              <item>Red</item>
+              <item>Blue</item>
+          </string-array>
+      </resources>
+      """.trimIndent(),
+    )
+    val targets = gotoTargets("val x = Res.array.<caret>colors")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertInstanceOf(targets[0], XmlAttributeValue::class.java)
+    assertEquals("colors", (targets[0] as XmlAttributeValue).value)
+  }
+
+  fun testNavigateToPluralsInSeparateXmlFile() {
+    addComposeResource(
+      "values/plurals.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <plurals name="messages">
+              <item quantity="one">%d message</item>
+              <item quantity="other">%d messages</item>
+          </plurals>
+      </resources>
+      """.trimIndent(),
+    )
+    val targets = gotoTargets("val x = Res.plurals.<caret>messages")
+
+    assertNotNull(targets)
+    assertEquals(1, targets!!.size)
+    assertInstanceOf(targets[0], XmlAttributeValue::class.java)
+    assertEquals("messages", (targets[0] as XmlAttributeValue).value)
+  }
+
   fun testNavigateToDrawablePng() {
     addComposeResource("drawable/icon.png", "fake-png-content")
     val targets = gotoTargets("val x = Res.drawable.<caret>icon")


### PR DESCRIPTION
## Summary
- Adds `ResourceGotoDeclarationHandler` supporting navigation to all Compose Multiplatform resource types: `string`, `array`, `plurals`, `drawable`, and `font`
- Adds 16 tests covering XML resource navigation, file resource navigation, scoping/exclusion, and edge cases
- Adds JUnit test dependency to `build.gradle.kts`

## Test plan
- [x] `./gradlew test` — all 16 tests pass
- [x] `./gradlew buildPlugin` — builds cleanly