### PR TITLE
Feature: Strings inspections

### DIFF
--- a/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspection.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspection.kt
@@ -1,0 +1,145 @@
+package dev.jordond.composeresourceskit.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import dev.jordond.composeresourceskit.RESOURCE_PREFIXES
+import dev.jordond.composeresourceskit.ResourceReference
+import dev.jordond.composeresourceskit.ResourceResolver
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+private const val COMPOSE_RESOURCES_PACKAGE = "org.jetbrains.compose.resources"
+
+private val TARGET_FUNCTIONS = mapOf(
+  "stringResource" to FunctionKind.STRING_RESOURCE,
+  "pluralStringResource" to FunctionKind.PLURAL_STRING_RESOURCE,
+)
+
+private enum class FunctionKind(
+  /** Number of leading non-format arguments (resource ref, quantity, etc.) */
+  val leadingArgCount: Int,
+  val displayName: String,
+) {
+  STRING_RESOURCE(leadingArgCount = 1, displayName = "stringResource"),
+  PLURAL_STRING_RESOURCE(leadingArgCount = 2, displayName = "pluralStringResource"),
+}
+
+class ComposeResourceArgumentInspection : LocalInspectionTool() {
+  override fun buildVisitor(
+    holder: ProblemsHolder,
+    isOnTheFly: Boolean,
+  ): PsiElementVisitor {
+    return object : KtVisitorVoid() {
+      override fun visitCallExpression(expression: KtCallExpression) {
+        val calleeText = expression.calleeExpression?.text ?: return
+        if (calleeText !in TARGET_FUNCTIONS) return
+
+        // Quick PSI-level check: does the first argument look like a resource reference?
+        val args = expression.valueArguments
+        if (args.isEmpty()) return
+
+        val firstArg = args[0].getArgumentExpression() ?: return
+        val isResourceRef = RESOURCE_PREFIXES.any { (prefix, _) ->
+          firstArg.text.startsWith(prefix)
+        }
+        if (!isResourceRef) return
+
+        // Resolve via K2 Analysis API to confirm it's the Compose Resources function
+        val functionKind = resolveFunction(expression) ?: return
+
+        // Extract the resource reference
+        val resourceRef = extractResourceRef(firstArg) ?: return
+        if (resourceRef !is ResourceReference.XmlResource) return
+
+        // Look up the XML resource to count format specifiers
+        val xmlTags = ResourceResolver.findXmlResources(expression.project, resourceRef)
+        if (xmlTags.isEmpty()) return
+
+        // Get the max format argument count across all matching tags (handles qualifiers)
+        val expectedArgCount = xmlTags.maxOf { tag ->
+          when (tag.name) {
+            "plurals" -> {
+              tag.findSubTags("item").maxOfOrNull { item ->
+                FormatSpecifierParser.countFormatArguments(item.value.text)
+              } ?: 0
+            }
+            else -> FormatSpecifierParser.countFormatArguments(tag.value.text)
+          }
+        }
+
+        // Count format arguments at the call site
+        val totalArgs = args.size
+        val formatArgCount = (totalArgs - functionKind.leadingArgCount).coerceAtLeast(0)
+
+        if (formatArgCount != expectedArgCount) {
+          val message = buildMessage(functionKind, expectedArgCount, formatArgCount, resourceRef)
+          holder.registerProblem(expression, message)
+        }
+      }
+    }
+  }
+
+  /**
+   * Uses K2 Analysis API to resolve the call and confirm it targets
+   * a Compose Resources function (`stringResource` or `pluralStringResource`).
+   *
+   * Returns the [FunctionKind] if confirmed, null otherwise.
+   */
+  private fun resolveFunction(expression: KtCallExpression): FunctionKind? {
+    return try {
+      analyze(expression) {
+        val call = expression
+          .resolveToCall()
+          ?.successfulFunctionCallOrNull() ?: return@analyze null
+
+        val symbol = call.partiallyAppliedSymbol.symbol
+        val callableId = symbol.callableId ?: return@analyze null
+
+        if (callableId.className != null) return@analyze null
+        if (callableId.packageName.asString() != COMPOSE_RESOURCES_PACKAGE) return@analyze null
+
+        TARGET_FUNCTIONS[callableId.callableName.asString()]
+      }
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private fun extractResourceRef(expression: org.jetbrains.kotlin.psi.KtExpression): ResourceReference? {
+    if (expression is KtDotQualifiedExpression) {
+      return ResourceResolver.extractResourceReference(expression)
+    }
+    return null
+  }
+
+  private fun buildMessage(
+    kind: FunctionKind,
+    expected: Int,
+    actual: Int,
+    ref: ResourceReference.XmlResource,
+  ): String {
+    val base = "${kind.displayName}(Res.${resTypePrefix(ref)}${ref.key}) " +
+      "expects $expected format argument${if (expected != 1) "s" else ""}, " +
+      "but $actual ${if (actual != 1) "were" else "was"} provided"
+
+    if (kind == FunctionKind.PLURAL_STRING_RESOURCE && actual == 0 && expected > 0) {
+      return "$base. Note: the quantity parameter is NOT a format argument — " +
+        "you likely need to pass it again as a format argument"
+    }
+
+    return base
+  }
+
+  private fun resTypePrefix(ref: ResourceReference.XmlResource): String =
+    when (ref.xmlTag) {
+      "string" -> "string."
+      "string-array" -> "array."
+      "plurals" -> "plurals."
+      else -> "${ref.xmlTag}."
+    }
+}

--- a/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceEscapeInspection.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceEscapeInspection.kt
@@ -1,0 +1,247 @@
+package dev.jordond.composeresourceskit.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.XmlElementVisitor
+import com.intellij.psi.xml.XmlTag
+import com.intellij.psi.xml.XmlText
+import dev.jordond.composeresourceskit.isInComposeResources
+
+/**
+ * Detects unnecessary Android-style backslash escapes in Compose Multiplatform resource strings.
+ *
+ * Unlike Android, Compose Multiplatform does not require escaping `'`, `"`, `@`, or `?`.
+ * Using these escapes can cause the backslash to appear literally in the rendered string.
+ */
+class ComposeResourceEscapeInspection : LocalInspectionTool() {
+  override fun buildVisitor(
+    holder: ProblemsHolder,
+    isOnTheFly: Boolean,
+  ): PsiElementVisitor {
+    return object : XmlElementVisitor() {
+      override fun visitXmlTag(tag: XmlTag) {
+        val virtualFile = tag.containingFile?.virtualFile ?: return
+        if (!virtualFile.isInComposeResources()) return
+
+        val parentDir = virtualFile.parent?.name ?: return
+        if (!parentDir.startsWith("values")) return
+
+        when (tag.name) {
+          "string" -> checkTag(tag, holder)
+          "plurals" -> {
+            for (itemTag in tag.findSubTags("item")) {
+              checkTag(itemTag, holder)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private fun checkTag(
+    tag: XmlTag,
+    holder: ProblemsHolder,
+  ) {
+    val textContent = tag.value.text
+    if (textContent.isEmpty()) return
+
+    val escapes = findUnnecessaryEscapes(textContent)
+    if (escapes.isEmpty()) return
+
+    for (escape in escapes) {
+      val textElement = findTextElementContaining(tag, escape.position)
+      val target = textElement ?: tag
+      holder.registerProblem(
+        target,
+        "Unnecessary Android escape '\\${escape.character}'. " +
+          "Compose Multiplatform does not require escaping '${escape.character}'",
+        ProblemHighlightType.WARNING,
+        RemoveUnnecessaryEscapeQuickFix(escape.character),
+      )
+    }
+
+    if (escapes.size > 1) {
+      val textElement = findTextElementContaining(tag, escapes.first().position)
+      val target = textElement ?: tag
+      holder.registerProblem(
+        target,
+        "Contains ${escapes.size} unnecessary Android escapes",
+        ProblemHighlightType.WARNING,
+        RemoveAllUnnecessaryEscapesQuickFix(),
+      )
+    }
+  }
+
+  private fun findTextElementContaining(
+    tag: XmlTag,
+    position: Int,
+  ): XmlText? {
+    var offset = 0
+    for (child in tag.value.children) {
+      if (child is XmlText) {
+        val childLength = child.text.length
+        if (position >= offset && position < offset + childLength) {
+          return child
+        }
+        offset += childLength
+      }
+    }
+    return null
+  }
+
+  companion object {
+    private val UNNECESSARY_ESCAPES = charArrayOf('\'', '"', '@', '?')
+
+    data class UnnecessaryEscape(
+      val position: Int,
+      val character: Char,
+    )
+
+    fun findUnnecessaryEscapes(text: String): List<UnnecessaryEscape> {
+      val results = mutableListOf<UnnecessaryEscape>()
+      var i = 0
+      while (i < text.length - 1) {
+        if (text[i] == '\\') {
+          val next = text[i + 1]
+          when {
+            next == '\\' -> i += 2 // escaped backslash, skip both
+            next == 'n' || next == 't' -> i += 2 // valid escape
+            next == 'u' &&
+              i + 5 < text.length &&
+              text.substring(i + 2, i + 6).all { it.isHexDigit() } -> i += 6 // unicode
+
+            next in UNNECESSARY_ESCAPES -> {
+              results.add(UnnecessaryEscape(i, next))
+              i += 2
+            }
+
+            else -> i += 2 // unknown escape, skip
+          }
+        } else {
+          i++
+        }
+      }
+      return results
+    }
+
+    private fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
+  }
+}
+
+private class RemoveUnnecessaryEscapeQuickFix(
+  private val escapedChar: Char,
+) : LocalQuickFix {
+  override fun getName(): String = "Remove unnecessary escape '\\$escapedChar'"
+
+  override fun getFamilyName(): String = "Remove unnecessary Android escape"
+
+  override fun applyFix(
+    project: Project,
+    descriptor: ProblemDescriptor,
+  ) {
+    val element = descriptor.psiElement ?: return
+    val tag = generateSequence(element) { it.parent }
+      .filterIsInstance<XmlTag>()
+      .firstOrNull() ?: return
+
+    val oldText = tag.value.text
+    val newText = removeEscape(oldText, escapedChar)
+    if (newText != oldText) {
+      tag.value.text = newText
+    }
+  }
+
+  private fun removeEscape(
+    text: String,
+    char: Char,
+  ): String {
+    val sb = StringBuilder()
+    var i = 0
+    var removed = false
+    while (i < text.length) {
+      if (!removed && i < text.length - 1 && text[i] == '\\' && text[i + 1] == char) {
+        // Check this backslash isn't itself escaped
+        if (!isPrecededByOddBackslashes(text, i)) {
+          sb.append(char)
+          i += 2
+          removed = true
+          continue
+        }
+      }
+      sb.append(text[i])
+      i++
+    }
+    return sb.toString()
+  }
+
+  private fun isPrecededByOddBackslashes(
+    text: String,
+    index: Int,
+  ): Boolean {
+    var count = 0
+    var j = index - 1
+    while (j >= 0 && text[j] == '\\') {
+      count++
+      j--
+    }
+    return count % 2 == 1
+  }
+}
+
+private class RemoveAllUnnecessaryEscapesQuickFix : LocalQuickFix {
+  override fun getName(): String = "Remove all unnecessary Android escapes"
+
+  override fun getFamilyName(): String = "Remove unnecessary Android escape"
+
+  override fun applyFix(
+    project: Project,
+    descriptor: ProblemDescriptor,
+  ) {
+    val element = descriptor.psiElement ?: return
+    val tag = generateSequence(element) { it.parent }
+      .filterIsInstance<XmlTag>()
+      .firstOrNull() ?: return
+
+    val oldText = tag.value.text
+    val newText = removeAllEscapes(oldText)
+    if (newText != oldText) {
+      tag.value.text = newText
+    }
+  }
+
+  private fun removeAllEscapes(text: String): String {
+    val unnecessaryChars = charArrayOf('\'', '"', '@', '?')
+    val sb = StringBuilder()
+    var i = 0
+    while (i < text.length) {
+      if (i < text.length - 1 && text[i] == '\\' && text[i + 1] in unnecessaryChars) {
+        if (!isPrecededByOddBackslashes(text, i)) {
+          sb.append(text[i + 1])
+          i += 2
+          continue
+        }
+      }
+      sb.append(text[i])
+      i++
+    }
+    return sb.toString()
+  }
+
+  private fun isPrecededByOddBackslashes(
+    text: String,
+    index: Int,
+  ): Boolean {
+    var count = 0
+    var j = index - 1
+    while (j >= 0 && text[j] == '\\') {
+      count++
+      j--
+    }
+    return count % 2 == 1
+  }
+}

--- a/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceFormatInspection.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceFormatInspection.kt
@@ -1,0 +1,178 @@
+package dev.jordond.composeresourceskit.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.XmlElementVisitor
+import com.intellij.psi.xml.XmlTag
+import com.intellij.psi.xml.XmlText
+import dev.jordond.composeresourceskit.isInComposeResources
+
+class ComposeResourceFormatInspection : LocalInspectionTool() {
+  override fun buildVisitor(
+    holder: ProblemsHolder,
+    isOnTheFly: Boolean,
+  ): PsiElementVisitor {
+    return object : XmlElementVisitor() {
+      override fun visitXmlTag(tag: XmlTag) {
+        val virtualFile = tag.containingFile?.virtualFile ?: return
+        if (!virtualFile.isInComposeResources()) return
+
+        val parentDir = virtualFile.parent?.name ?: return
+        if (!parentDir.startsWith("values")) return
+
+        when (tag.name) {
+          "string" -> validateStringTag(tag, holder)
+          "plurals" -> validatePluralsTag(tag, holder)
+        }
+      }
+    }
+  }
+
+  private fun validateStringTag(
+    tag: XmlTag,
+    holder: ProblemsHolder,
+  ) {
+    val textContent = tag.value.text
+    if (textContent.isBlank()) return
+
+    val issues = FormatSpecifierParser.validate(textContent)
+    reportIssues(tag, issues, holder)
+  }
+
+  private fun validatePluralsTag(
+    tag: XmlTag,
+    holder: ProblemsHolder,
+  ) {
+    val itemTags = tag.findSubTags("item")
+    if (itemTags.isEmpty()) return
+
+    // Validate each item individually
+    for (itemTag in itemTags) {
+      val textContent = itemTag.value.text
+      if (textContent.isBlank()) continue
+
+      val issues = FormatSpecifierParser.validate(textContent)
+      reportIssues(itemTag, issues, holder)
+    }
+
+    // Validate consistency across variants
+    val variants = itemTags
+      .mapNotNull { itemTag ->
+        val quantity = itemTag.getAttributeValue("quantity") ?: return@mapNotNull null
+        val text = itemTag.value.text
+        quantity to text
+      }.toMap()
+
+    val consistencyIssues = FormatSpecifierParser.validatePluralsConsistency(variants)
+    for (issue in consistencyIssues) {
+      if (issue is FormatSpecifierParser.ValidationResult.InconsistentPluralsSpecifiers) {
+        val itemTag = itemTags.firstOrNull {
+          it.getAttributeValue("quantity") == issue.variant
+        } ?: continue
+        holder.registerProblem(
+          itemTag,
+          "Plural variant '${issue.variant}' has ${issue.variantCount} format " +
+            "specifier(s), but other variants have ${issue.expectedCount}",
+          ProblemHighlightType.WARNING,
+        )
+      }
+    }
+  }
+
+  private fun reportIssues(
+    tag: XmlTag,
+    issues: List<FormatSpecifierParser.ValidationResult>,
+    holder: ProblemsHolder,
+  ) {
+    for (issue in issues) {
+      when (issue) {
+        is FormatSpecifierParser.ValidationResult.InvalidSpecifier -> {
+          val textElement = findTextElementContaining(tag, issue.range)
+          val target = textElement ?: tag
+          holder.registerProblem(
+            target,
+            "Invalid format specifier '${issue.specifier}'. " +
+              "Compose resources only support %N\$s and %N\$d (e.g., %1\$s, %2\$d)",
+            ProblemHighlightType.ERROR,
+            ConvertToPositionalSpecifierQuickFix(issue.specifier),
+          )
+        }
+
+        is FormatSpecifierParser.ValidationResult.NonSequentialNumbering -> {
+          holder.registerProblem(
+            tag,
+            "Format specifier positions are not sequential. " +
+              "Expected ${issue.expected}, found ${issue.actual}",
+            ProblemHighlightType.WARNING,
+          )
+        }
+
+        is FormatSpecifierParser.ValidationResult.Valid,
+        is FormatSpecifierParser.ValidationResult.InconsistentPluralsSpecifiers,
+        -> Unit
+      }
+    }
+  }
+
+  /**
+   * Find the XmlText child of a tag that contains the given character range.
+   */
+  private fun findTextElementContaining(
+    tag: XmlTag,
+    range: IntRange,
+  ): XmlText? {
+    var offset = 0
+    for (child in tag.value.children) {
+      if (child is XmlText) {
+        val childLength = child.text.length
+        if (range.first >= offset && range.first < offset + childLength) {
+          return child
+        }
+        offset += childLength
+      }
+    }
+    return null
+  }
+}
+
+private class ConvertToPositionalSpecifierQuickFix(
+  private val invalidSpecifier: String,
+) : LocalQuickFix {
+  override fun getName(): String = "Convert '$invalidSpecifier' to positional specifier"
+
+  override fun getFamilyName(): String = "Convert to positional format specifier"
+
+  override fun applyFix(
+    project: Project,
+    descriptor: ProblemDescriptor,
+  ) {
+    val element = descriptor.psiElement ?: return
+    val tag = generateSequence(element) { it.parent }
+      .filterIsInstance<XmlTag>()
+      .firstOrNull() ?: return
+
+    val oldText = tag.value.text
+
+    // Collect existing positional specifiers to determine next position
+    val existingSpecifiers = FormatSpecifierParser.extractSpecifiers(oldText)
+    val maxPosition = existingSpecifiers.maxOfOrNull { it.position } ?: 0
+
+    // Replace unpositioned specifiers with positional ones
+    var nextPosition = maxPosition + 1
+    val newText = oldText.replace(Regex("""%([sd])""")) { match ->
+      val type = match.groupValues[1]
+      val replacement = "%${nextPosition}\$$type"
+      nextPosition++
+      replacement
+    }
+
+    if (newText != oldText) {
+      tag.value.text = newText
+    }
+  }
+}

--- a/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceFormatInspection.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceFormatInspection.kt
@@ -99,7 +99,7 @@ class ComposeResourceFormatInspection : LocalInspectionTool() {
             "Invalid format specifier '${issue.specifier}'. " +
               "Compose resources only support %N\$s and %N\$d (e.g., %1\$s, %2\$d)",
             ProblemHighlightType.ERROR,
-            ConvertToPositionalSpecifierQuickFix(issue.specifier),
+            ConvertToPositionalSpecifierQuickFix(),
           )
         }
 
@@ -140,10 +140,8 @@ class ComposeResourceFormatInspection : LocalInspectionTool() {
   }
 }
 
-private class ConvertToPositionalSpecifierQuickFix(
-  private val invalidSpecifier: String,
-) : LocalQuickFix {
-  override fun getName(): String = "Convert '$invalidSpecifier' to positional specifier"
+private class ConvertToPositionalSpecifierQuickFix : LocalQuickFix {
+  override fun getName(): String = "Convert all unpositioned specifiers to positional format"
 
   override fun getFamilyName(): String = "Convert to positional format specifier"
 

--- a/src/main/kotlin/dev/jordond/composeresourceskit/inspection/FormatSpecifierParser.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/inspection/FormatSpecifierParser.kt
@@ -1,0 +1,135 @@
+package dev.jordond.composeresourceskit.inspection
+
+/**
+ * Parses and validates Compose Multiplatform format specifiers.
+ *
+ * Compose Multiplatform only supports `%N$s` and `%N$d` (1-indexed positional specifiers).
+ * Unlike Java's String.format(), unpositioned `%s`/`%d`, width/precision modifiers, and
+ * other conversion types (`%f`, `%x`, `%b`, etc.) are NOT supported.
+ */
+object FormatSpecifierParser {
+  /** Matches valid Compose format specifiers: %1$s, %2$d, etc. */
+  private val VALID_SPECIFIER = Regex("""%(\d+)\$([sd])""")
+
+  /** Matches any %-sequence that looks like a format specifier (valid or not). */
+  private val ANY_PERCENT_SEQUENCE = Regex("""%(?!%)[\d$\w.*-+#(]*[a-zA-Z]""")
+
+  /** Matches literal %% (escaped percent). */
+  private val ESCAPED_PERCENT = Regex("""%%""")
+
+  data class SpecifierInfo(
+    val position: Int,
+    val type: Char,
+    val fullMatch: String,
+    val range: IntRange,
+  )
+
+  sealed interface ValidationResult {
+    data object Valid : ValidationResult
+
+    data class InvalidSpecifier(
+      val specifier: String,
+      val range: IntRange,
+    ) : ValidationResult
+
+    data class NonSequentialNumbering(
+      val expected: List<Int>,
+      val actual: List<Int>,
+    ) : ValidationResult
+
+    data class InconsistentPluralsSpecifiers(
+      val variant: String,
+      val variantCount: Int,
+      val expectedCount: Int,
+      val expectedPositions: List<Int>,
+    ) : ValidationResult
+  }
+
+  /**
+   * Extracts all valid format specifiers from a string.
+   */
+  fun extractSpecifiers(text: String): List<SpecifierInfo> =
+    VALID_SPECIFIER
+      .findAll(text)
+      .map { match ->
+        SpecifierInfo(
+          position = match.groupValues[1].toInt(),
+          type = match.groupValues[2][0],
+          fullMatch = match.value,
+          range = match.range,
+        )
+      }.toList()
+
+  /**
+   * Counts the number of distinct format argument positions in a string.
+   * e.g., "Hello %1$s, you have %2$d items" -> 2
+   */
+  fun countFormatArguments(text: String): Int = extractSpecifiers(text).maxOfOrNull { it.position } ?: 0
+
+  /**
+   * Validates format specifiers in a single string value.
+   * Returns a list of validation issues found.
+   */
+  fun validate(text: String): List<ValidationResult> {
+    val issues = mutableListOf<ValidationResult>()
+
+    // Find all %-sequences and check if they're valid
+    val validRanges = VALID_SPECIFIER.findAll(text).map { it.range }.toSet()
+    val escapedRanges = ESCAPED_PERCENT.findAll(text).map { it.range }.toSet()
+
+    ANY_PERCENT_SEQUENCE.findAll(text).forEach { match ->
+      val isValid = validRanges.any { it.first == match.range.first }
+      val isEscaped = escapedRanges.any { match.range.first in it }
+      if (!isValid && !isEscaped) {
+        issues.add(ValidationResult.InvalidSpecifier(match.value, match.range))
+      }
+    }
+
+    // Check sequential numbering
+    val specifiers = extractSpecifiers(text)
+    if (specifiers.isNotEmpty()) {
+      val positions = specifiers.map { it.position }.distinct().sorted()
+      val expected = (1..positions.max()).toList()
+      if (positions != expected) {
+        issues.add(ValidationResult.NonSequentialNumbering(expected, positions))
+      }
+    }
+
+    return issues
+  }
+
+  /**
+   * Validates that all plural variants have consistent format specifiers.
+   * Takes a map of quantity -> text content (e.g., "one" -> "%1$d item", "other" -> "%1$d items").
+   * Returns issues if variants have different specifier counts or positions.
+   */
+  fun validatePluralsConsistency(variants: Map<String, String>): List<ValidationResult> {
+    if (variants.size <= 1) return emptyList()
+
+    val issues = mutableListOf<ValidationResult>()
+    val variantSpecifiers = variants.mapValues { (_, text) ->
+      extractSpecifiers(text).map { it.position }.distinct().sorted()
+    }
+
+    // Use the variant with the most specifiers as the reference
+    val reference = variantSpecifiers.maxByOrNull { it.value.size } ?: return emptyList()
+    val expectedPositions = reference.value
+    val expectedCount = expectedPositions.size
+
+    for ((variant, positions) in variantSpecifiers) {
+      if (variant == reference.key) continue
+      if (positions != expectedPositions) {
+        issues.add(
+          ValidationResult.InconsistentPluralsSpecifiers(
+            variant = variant,
+            variantCount = positions.size,
+            expectedCount = expectedCount,
+            expectedPositions = expectedPositions,
+          ),
+        )
+      }
+    }
+
+    return issues
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -46,6 +46,22 @@
             groupName="Compose Resources Kit"
             enabledByDefault="true"
             level="WARNING"/>
+
+        <localInspection
+            language="XML"
+            implementationClass="dev.jordond.composeresourceskit.inspection.ComposeResourceFormatInspection"
+            displayName="Invalid Compose resource format specifier"
+            groupName="Compose Resources Kit"
+            enabledByDefault="true"
+            level="ERROR"/>
+
+        <localInspection
+            language="kotlin"
+            implementationClass="dev.jordond.composeresourceskit.inspection.ComposeResourceArgumentInspection"
+            displayName="Compose resource format argument mismatch"
+            groupName="Compose Resources Kit"
+            enabledByDefault="true"
+            level="WARNING"/>
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -56,6 +56,14 @@
             level="ERROR"/>
 
         <localInspection
+            language="XML"
+            implementationClass="dev.jordond.composeresourceskit.inspection.ComposeResourceEscapeInspection"
+            displayName="Unnecessary Android escape in Compose resource"
+            groupName="Compose Resources Kit"
+            enabledByDefault="true"
+            level="WARNING"/>
+
+        <localInspection
             language="kotlin"
             implementationClass="dev.jordond.composeresourceskit.inspection.ComposeResourceArgumentInspection"
             displayName="Compose resource format argument mismatch"

--- a/src/main/resources/inspectionDescriptions/ComposeResourceArgument.html
+++ b/src/main/resources/inspectionDescriptions/ComposeResourceArgument.html
@@ -1,0 +1,30 @@
+<html>
+<body>
+Reports mismatches between the number of format arguments passed to
+<code>stringResource()</code> or <code>pluralStringResource()</code> and the number of
+format specifiers defined in the corresponding XML resource.
+<p>
+    For example, if a string resource contains <code>%1$s</code> and <code>%2$d</code>,
+    the call site must provide exactly 2 format arguments after the resource reference.
+    For <code>pluralStringResource()</code>, note that the quantity parameter is not
+    counted as a format argument.
+</p>
+<p>Example of a <code>stringResource</code> call with a missing argument:</p>
+<pre><code>
+// strings.xml: &lt;string name="greeting"&gt;Hello %1$s, you have %2$d items&lt;/string&gt;
+
+// Warning: expects 2 format arguments, but 1 was provided
+stringResource(Res.string.greeting, name)
+</code></pre>
+<p>Correct usage:</p>
+<pre><code>
+stringResource(Res.string.greeting, name, count)
+</code></pre>
+<!-- tooltip end -->
+<p>
+    This inspection resolves <code>stringResource</code> and <code>pluralStringResource</code>
+    calls from the <code>org.jetbrains.compose.resources</code> package and cross-references
+    the format specifiers found in the XML resource definition.
+</p>
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/ComposeResourceArgument.html
+++ b/src/main/resources/inspectionDescriptions/ComposeResourceArgument.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <body>
 Reports mismatches between the number of format arguments passed to
 <code>stringResource()</code> or <code>pluralStringResource()</code> and the number of

--- a/src/main/resources/inspectionDescriptions/ComposeResourceEscape.html
+++ b/src/main/resources/inspectionDescriptions/ComposeResourceEscape.html
@@ -1,0 +1,34 @@
+<html lang="en">
+<body>
+Reports unnecessary Android-style backslash escapes in Compose Multiplatform string and plural resources.
+<p>
+    Unlike Android, Compose Multiplatform does not require escaping <code>'</code>,
+    <code>"</code>, <code>@</code>, or <code>?</code> with a backslash. Using these
+    Android escapes in Compose resources cause the backslash to appear literally
+    in the rendered string.
+</p>
+<p>Example of problematic code:</p>
+<pre><code>
+&lt;string name="greeting"&gt;Let\'s do something&lt;/string&gt;
+</code></pre>
+<p>After the quick fix is applied:</p>
+<pre><code>
+&lt;string name="greeting"&gt;Let's do something&lt;/string&gt;
+</code></pre>
+<!-- tooltip end -->
+<p>
+    The following backslash escapes are flagged as unnecessary:
+</p>
+<ul>
+    <li><code>\'</code> &mdash; apostrophe does not need escaping</li>
+    <li><code>\"</code> &mdash; double quote does not need escaping</li>
+    <li><code>\@</code> &mdash; <code>@</code> is not treated as a resource reference</li>
+    <li><code>\?</code> &mdash; <code>?</code> is not treated as a theme attribute</li>
+</ul>
+<p>
+    Valid backslash sequences (<code>\n</code>, <code>\t</code>, <code>\\</code>,
+    <code>\uXXXX</code>) and standard XML entities (<code>&amp;amp;</code>,
+    <code>&amp;lt;</code>, <code>&amp;apos;</code>) are not affected by this inspection.
+</p>
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/ComposeResourceEscape.html
+++ b/src/main/resources/inspectionDescriptions/ComposeResourceEscape.html
@@ -4,7 +4,7 @@ Reports unnecessary Android-style backslash escapes in Compose Multiplatform str
 <p>
     Unlike Android, Compose Multiplatform does not require escaping <code>'</code>,
     <code>"</code>, <code>@</code>, or <code>?</code> with a backslash. Using these
-    Android escapes in Compose resources cause the backslash to appear literally
+    Android escapes in Compose resources causes the backslash to appear literally
     in the rendered string.
 </p>
 <p>Example of problematic code:</p>

--- a/src/main/resources/inspectionDescriptions/ComposeResourceFormat.html
+++ b/src/main/resources/inspectionDescriptions/ComposeResourceFormat.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <body>
 Reports invalid format specifiers in Compose Multiplatform string and plural resources.
 <p>

--- a/src/main/resources/inspectionDescriptions/ComposeResourceFormat.html
+++ b/src/main/resources/inspectionDescriptions/ComposeResourceFormat.html
@@ -1,0 +1,29 @@
+<html>
+<body>
+Reports invalid format specifiers in Compose Multiplatform string and plural resources.
+<p>
+    Compose Multiplatform only supports positional format specifiers in the form
+    <code>%N$s</code> (string) and <code>%N$d</code> (integer), where <code>N</code> is a
+    1-based index. Unlike Java's <code>String.format()</code>, unpositioned specifiers like
+    <code>%s</code> or <code>%d</code>, as well as width/precision modifiers and other
+    conversion types (<code>%f</code>, <code>%x</code>, <code>%b</code>), are not supported.
+</p>
+<p>
+    This inspection also verifies that specifier positions are sequential (starting from 1
+    with no gaps) and that all plural variants use a consistent set of format specifiers.
+</p>
+<p>Example of problematic code:</p>
+<pre><code>
+&lt;string name="greeting"&gt;Hello %s, you have %d items&lt;/string&gt;
+</code></pre>
+<p>After the quick fix is applied:</p>
+<pre><code>
+&lt;string name="greeting"&gt;Hello %1$s, you have %2$d items&lt;/string&gt;
+</code></pre>
+<!-- tooltip end -->
+<p>
+    Use the provided 'Convert to positional format specifier' quick fix to automatically
+    replace unpositioned specifiers with the correct positional syntax.
+</p>
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/UnusedComposeResource.html
+++ b/src/main/resources/inspectionDescriptions/UnusedComposeResource.html
@@ -1,9 +1,8 @@
-<html>
+<html lang="en">
 <body>
 Reports string, plural, and array resources defined in Compose Multiplatform XML files
 that are not referenced anywhere in the project's Kotlin code.
 <p>
-    Unused resources increase bundle size and make resource files harder to maintain.
     This inspection searches the project for references matching the resource's
     generated accessor (e.g., <code>Res.string.greeting</code>) and highlights
     resources with no usages found.

--- a/src/main/resources/inspectionDescriptions/UnusedComposeResource.html
+++ b/src/main/resources/inspectionDescriptions/UnusedComposeResource.html
@@ -1,0 +1,22 @@
+<html>
+<body>
+Reports string, plural, and array resources defined in Compose Multiplatform XML files
+that are not referenced anywhere in the project's Kotlin code.
+<p>
+    Unused resources increase bundle size and make resource files harder to maintain.
+    This inspection searches the project for references matching the resource's
+    generated accessor (e.g., <code>Res.string.greeting</code>) and highlights
+    resources with no usages found.
+</p>
+<p>Example:</p>
+<pre><code>
+&lt;!-- Highlighted as unused if no Kotlin code references Res.string.old_message --&gt;
+&lt;string name="old_message"&gt;This message is no longer used&lt;/string&gt;
+</code></pre>
+<!-- tooltip end -->
+<p>
+    Use the provided 'Remove unused resource' quick fix to delete the resource
+    element from the XML file.
+</p>
+</body>
+</html>

--- a/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspectionTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspectionTest.kt
@@ -1,0 +1,330 @@
+package dev.jordond.composeresourceskit.inspection
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class ComposeResourceArgumentInspectionTest : BasePlatformTestCase() {
+  override fun setUp() {
+    super.setUp()
+    myFixture.enableInspections(ComposeResourceArgumentInspection())
+    addComposeResourcesStubs()
+  }
+
+  /**
+   * Adds source stubs for the Compose Resources library types and functions
+   * so that K2 Analysis API can resolve calls in test fixtures.
+   */
+  private fun addComposeResourcesStubs() {
+    myFixture.addFileToProject(
+      "stubs/StringResource.kt",
+      """
+      package org.jetbrains.compose.resources
+
+      class StringResource(val id: String)
+      class PluralStringResource(val id: String)
+
+      fun stringResource(resource: StringResource): String = ""
+      fun stringResource(resource: StringResource, vararg formatArgs: Any): String = ""
+      fun pluralStringResource(resource: PluralStringResource, quantity: Int): String = ""
+      fun pluralStringResource(resource: PluralStringResource, quantity: Int, vararg formatArgs: Any): String = ""
+      """.trimIndent(),
+    )
+  }
+
+  /**
+   * Adds a stub Res object with typed resource accessors for the given resource names.
+   */
+  private fun addResStub(
+    strings: List<String> = emptyList(),
+    plurals: List<String> = emptyList(),
+  ) {
+    val stringFields = strings.joinToString("\n        ") {
+      "val $it = org.jetbrains.compose.resources.StringResource(\"$it\")"
+    }
+    val pluralFields = plurals.joinToString("\n        ") {
+      "val $it = org.jetbrains.compose.resources.PluralStringResource(\"$it\")"
+    }
+
+    myFixture.addFileToProject(
+      "stubs/Res.kt",
+      """
+      object Res {
+          object string {
+              $stringFields
+          }
+          object plurals {
+              $pluralFields
+          }
+      }
+      """.trimIndent(),
+    )
+  }
+
+  private fun addComposeResource(
+    path: String,
+    content: String,
+  ) {
+    myFixture.addFileToProject("composeResources/$path", content)
+  }
+
+  // -- stringResource: correct argument counts --
+
+  fun testStringResourceNoArgsNeededNonePassed() {
+    addResStub(strings = listOf("no_args"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="no_args">Hello world</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.stringResource
+
+      fun test() {
+          stringResource(Res.string.no_args)
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertTrue("No args needed, none passed should be OK", argMismatches.isEmpty())
+  }
+
+  fun testStringResourceOneArgNeededOnePassed() {
+    addResStub(strings = listOf("one_arg"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="one_arg">Hello %1${'$'}s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.stringResource
+
+      fun test() {
+          stringResource(Res.string.one_arg, "world")
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertTrue("1 arg needed, 1 passed should be OK", argMismatches.isEmpty())
+  }
+
+  // -- stringResource: argument mismatches --
+
+  fun testStringResourceOneArgNeededNonePassed() {
+    addResStub(strings = listOf("one_arg"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="one_arg">Hello %1${'$'}s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.stringResource
+
+      fun test() {
+          stringResource(Res.string.one_arg)
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertFalse("1 arg needed, 0 passed should be flagged", argMismatches.isEmpty())
+  }
+
+  fun testStringResourceTwoArgsNeededOnePassed() {
+    addResStub(strings = listOf("two_args"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="two_args">Hello %1${'$'}s, you have %2${'$'}d items</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.stringResource
+
+      fun test() {
+          stringResource(Res.string.two_args, "world")
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertFalse("2 args needed, 1 passed should be flagged", argMismatches.isEmpty())
+  }
+
+  // -- pluralStringResource --
+
+  fun testPluralStringResourceCorrect() {
+    addResStub(plurals = listOf("items"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <plurals name="items">
+              <item quantity="one">%1${'$'}d item</item>
+              <item quantity="other">%1${'$'}d items</item>
+          </plurals>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.pluralStringResource
+
+      fun test() {
+          val count = 5
+          pluralStringResource(Res.plurals.items, count, count)
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertTrue("Correct plural args should be OK", argMismatches.isEmpty())
+  }
+
+  fun testPluralStringResourceMissingFormatArg() {
+    addResStub(plurals = listOf("items"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <plurals name="items">
+              <item quantity="one">%1${'$'}d item</item>
+              <item quantity="other">%1${'$'}d items</item>
+          </plurals>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.pluralStringResource
+
+      fun test() {
+          val count = 5
+          pluralStringResource(Res.plurals.items, count)
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertFalse(
+      "Missing format arg (only quantity passed) should be flagged",
+      argMismatches.isEmpty(),
+    )
+  }
+
+  fun testPluralStringResourceQuantityHint() {
+    addResStub(plurals = listOf("items"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <plurals name="items">
+              <item quantity="one">%1${'$'}d item</item>
+              <item quantity="other">%1${'$'}d items</item>
+          </plurals>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.pluralStringResource
+
+      fun test() {
+          val count = 5
+          pluralStringResource(Res.plurals.items, count)
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val quantityHints = highlights.filter {
+      it.description?.contains("quantity parameter is NOT a format argument") == true
+    }
+
+    assertFalse(
+      "Should include hint about quantity not being a format arg",
+      quantityHints.isEmpty(),
+    )
+  }
+
+  // -- Non-resource calls should be ignored --
+
+  fun testIgnoresNonResourceCalls() {
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      fun stringResource(key: String): String = key
+      fun test() {
+          stringResource("hello")
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertTrue("Non-compose stringResource calls should be ignored", argMismatches.isEmpty())
+  }
+}

--- a/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspectionTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspectionTest.kt
@@ -66,8 +66,6 @@ class ComposeResourceArgumentInspectionTest : BasePlatformTestCase() {
     myFixture.addFileToProject("composeResources/$path", content)
   }
 
-  // -- stringResource: correct argument counts --
-
   fun testStringResourceNoArgsNeededNonePassed() {
     addResStub(strings = listOf("no_args"))
     addComposeResource(
@@ -130,8 +128,6 @@ class ComposeResourceArgumentInspectionTest : BasePlatformTestCase() {
     assertTrue("1 arg needed, 1 passed should be OK", argMismatches.isEmpty())
   }
 
-  // -- stringResource: argument mismatches --
-
   fun testStringResourceOneArgNeededNonePassed() {
     addResStub(strings = listOf("one_arg"))
     addComposeResource(
@@ -193,8 +189,6 @@ class ComposeResourceArgumentInspectionTest : BasePlatformTestCase() {
 
     assertFalse("2 args needed, 1 passed should be flagged", argMismatches.isEmpty())
   }
-
-  // -- pluralStringResource --
 
   fun testPluralStringResourceCorrect() {
     addResStub(plurals = listOf("items"))
@@ -306,8 +300,6 @@ class ComposeResourceArgumentInspectionTest : BasePlatformTestCase() {
       quantityHints.isEmpty(),
     )
   }
-
-  // -- Non-resource calls should be ignored --
 
   fun testIgnoresNonResourceCalls() {
     myFixture.configureByText(

--- a/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceEscapeInspectionTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceEscapeInspectionTest.kt
@@ -1,0 +1,566 @@
+package dev.jordond.composeresourceskit.inspection
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class ComposeResourceEscapeInspectionTest : BasePlatformTestCase() {
+  override fun setUp() {
+    super.setUp()
+    myFixture.enableInspections(ComposeResourceEscapeInspection())
+  }
+
+  private fun addComposeResource(
+    path: String,
+    content: String,
+  ) {
+    myFixture.addFileToProject("composeResources/$path", content)
+  }
+
+  private fun configureAndHighlight(path: String = "composeResources/values/strings.xml") =
+    myFixture.run {
+      val file = findFileInTempDir(path)!!
+      configureFromExistingVirtualFile(file)
+      doHighlighting()
+    }
+
+  private fun escapeWarnings() =
+    configureAndHighlight().filter {
+      it.description?.contains("Unnecessary Android escape") == true ||
+        it.description?.contains("unnecessary Android escapes") == true
+    }
+
+  // ── Unnecessary escapes that SHOULD be flagged ─────────────────────
+
+  fun testEscapedApostrophe() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="apos">Let\'s go</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Escaped apostrophe should be flagged",
+      warnings.any { it.description?.contains("\\'") == true },
+    )
+  }
+
+  fun testEscapedDoubleQuote() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="dquote">Say \"hello\"</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Escaped double quotes should be flagged",
+      warnings.any { it.description?.contains("\\\"") == true },
+    )
+  }
+
+  fun testEscapedAtSign() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="at">\@string/ref</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Escaped @ should be flagged",
+      warnings.any { it.description?.contains("\\@") == true },
+    )
+  }
+
+  fun testEscapedQuestionMark() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="question">Is it\?</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Escaped ? should be flagged",
+      warnings.any { it.description?.contains("\\?") == true },
+    )
+  }
+
+  fun testMultipleUnnecessaryEscapes() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="multi">Let\'s say \"hello\"</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    // Individual per-escape warnings + one "fix all" warning
+    assertTrue(
+      "Multiple unnecessary escapes should produce individual warnings",
+      warnings.count { it.description?.contains("Unnecessary Android escape '\\") == true } >= 3,
+    )
+    assertTrue(
+      "Should offer a 'fix all' warning",
+      warnings.any { it.description?.contains("unnecessary Android escapes") == true },
+    )
+  }
+
+  fun testEscapesInPlurals() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <plurals name="items">
+              <item quantity="one">%1${'$'}d item\'s total</item>
+              <item quantity="other">%1${'$'}d items\'s total</item>
+          </plurals>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Escapes in plural items should be flagged",
+      warnings.any { it.description?.contains("\\'") == true },
+    )
+  }
+
+  // ── Valid content that should NOT be flagged ───────────────────────
+
+  fun testPlainApostropheNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="plain">Let's go</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue("Plain apostrophe should not be flagged", warnings.isEmpty())
+  }
+
+  fun testValidNewlineEscape() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="newline">Line1\nLine2</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue("Valid \\n escape should not be flagged", warnings.isEmpty())
+  }
+
+  fun testValidTabEscape() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="tab">Col1\tCol2</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue("Valid \\t escape should not be flagged", warnings.isEmpty())
+  }
+
+  fun testValidEscapedBackslash() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="backslash">Back\\slash</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue("Valid \\\\ escape should not be flagged", warnings.isEmpty())
+  }
+
+  fun testValidUnicodeEscape() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="unicode">Heart \u2764</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue("Valid unicode escape should not be flagged", warnings.isEmpty())
+  }
+
+  fun testXmlEntitiesNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="entities">Tom &amp; Jerry &lt;3 &gt; &apos;hi&apos;</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue("XML entities should not be flagged", warnings.isEmpty())
+  }
+
+  fun testEscapedBackslashFollowedByApostrophe() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="dblback">\\'quote</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "\\\\' (escaped backslash + literal apostrophe) should not be flagged",
+      warnings.isEmpty(),
+    )
+  }
+
+  fun testPlainStringNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="plain">Hello world</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue("Plain text without escapes should not be flagged", warnings.isEmpty())
+  }
+
+  fun testEmptyStringNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="empty"></string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue("Empty string should not be flagged", warnings.isEmpty())
+  }
+
+  // ── Scoping ────────────────────────────────────────────────────────
+
+  fun testIgnoresFilesOutsideComposeResources() {
+    myFixture.addFileToProject(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="apos">Let\'s go</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+    val highlights = myFixture.doHighlighting()
+    val warnings = highlights.filter {
+      it.description?.contains("Unnecessary Android escape") == true
+    }
+
+    assertTrue("Should not inspect XML outside composeResources", warnings.isEmpty())
+  }
+
+  fun testIgnoresNonValuesDirectory() {
+    addComposeResource(
+      "drawable/icon.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="apos">Let\'s go</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/drawable/icon.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+    val highlights = myFixture.doHighlighting()
+    val warnings = highlights.filter {
+      it.description?.contains("Unnecessary Android escape") == true
+    }
+
+    assertTrue("Should not inspect XML in non-values directories", warnings.isEmpty())
+  }
+
+  // ── Edge cases ─────────────────────────────────────────────────────
+
+  fun testEscapeAtStartOfString() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="start">\'hello</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Escape at start of string should be flagged",
+      warnings.any { it.description?.contains("\\'") == true },
+    )
+  }
+
+  fun testEscapeAtEndOfString() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="end">hello\'</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Escape at end of string should be flagged",
+      warnings.any { it.description?.contains("\\'") == true },
+    )
+  }
+
+  fun testOnlyEscapeCharacter() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="only">\'</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "String containing only an escape should be flagged",
+      warnings.any { it.description?.contains("\\'") == true },
+    )
+  }
+
+  fun testMixedValidAndInvalidEscapes() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="mixed">Line1\nLet\'s go</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Should flag \\' but not \\n",
+      warnings.any { it.description?.contains("\\'") == true },
+    )
+    assertTrue(
+      "Should not flag \\n",
+      warnings.none { it.description?.contains("\\n") == true },
+    )
+  }
+
+  fun testAdjacentUnnecessaryEscapes() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="adjacent">\'\"</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val warnings = escapeWarnings()
+    assertTrue(
+      "Both adjacent escapes should be flagged",
+      warnings.any { it.description?.contains("\\'") == true },
+    )
+    assertTrue(
+      "Both adjacent escapes should be flagged",
+      warnings.any { it.description?.contains("\\\"") == true },
+    )
+  }
+
+  fun testLocalizedValuesDirectory() {
+    addComposeResource(
+      "values-fr/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="greeting">C\'est la vie</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values-fr/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+    val highlights = myFixture.doHighlighting()
+    val warnings = highlights.filter {
+      it.description?.contains("Unnecessary Android escape") == true
+    }
+
+    assertTrue(
+      "Should detect escapes in localized values directories",
+      warnings.isNotEmpty(),
+    )
+  }
+
+  // ── Quick fixes ────────────────────────────────────────────────────
+
+  fun testQuickFixRemovesSingleEscape() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="fix_me">Let\'s go</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    configureAndHighlight()
+
+    val fix = myFixture.getAllQuickFixes().firstOrNull {
+      it.text.contains("Remove unnecessary escape") && it.text.contains("\\'")
+    }
+    assertNotNull("Expected quick fix to remove escape", fix)
+    myFixture.launchAction(fix!!)
+
+    val text = myFixture.editor.document.text
+    assertTrue("Should contain unescaped apostrophe", text.contains("Let's go"))
+    assertFalse("Should not contain escaped apostrophe", text.contains("Let\\'s go"))
+  }
+
+  fun testQuickFixRemovesAllEscapes() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="fix_all">Let\'s say \"hello\"</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    configureAndHighlight()
+
+    val fix = myFixture.getAllQuickFixes().firstOrNull {
+      it.text.contains("Remove all unnecessary")
+    }
+    assertNotNull("Expected 'fix all' quick fix", fix)
+    myFixture.launchAction(fix!!)
+
+    val text = myFixture.editor.document.text
+    assertTrue("Should contain unescaped text", text.contains("Let's say \"hello\""))
+  }
+
+  fun testQuickFixPreservesValidEscapes() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="preserve">Line1\nLet\'s go\\path</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    configureAndHighlight()
+
+    val fix = myFixture.getAllQuickFixes().firstOrNull {
+      it.text.contains("Remove unnecessary escape") && it.text.contains("\\'")
+    }
+    assertNotNull("Expected quick fix", fix)
+    myFixture.launchAction(fix!!)
+
+    val text = myFixture.editor.document.text
+    assertTrue("Should preserve \\n", text.contains("\\n"))
+    assertTrue("Should preserve \\\\", text.contains("\\\\"))
+    assertTrue("Should remove \\'", text.contains("Let's go"))
+  }
+
+  // ── Unit tests for findUnnecessaryEscapes ──────────────────────────
+
+  fun testParserFindsApostropheEscape() {
+    val result = ComposeResourceEscapeInspection.findUnnecessaryEscapes("Let\\'s go")
+    assertEquals(1, result.size)
+    assertEquals('\'', result[0].character)
+    assertEquals(3, result[0].position)
+  }
+
+  fun testParserFindsAllFourEscapeTypes() {
+    val result = ComposeResourceEscapeInspection.findUnnecessaryEscapes("\\'\\\"\\@\\?")
+    assertEquals(4, result.size)
+    assertEquals(listOf('\'', '"', '@', '?'), result.map { it.character })
+  }
+
+  fun testParserSkipsValidEscapes() {
+    val result = ComposeResourceEscapeInspection.findUnnecessaryEscapes("\\n\\t\\\\\\u0027")
+    assertTrue("Valid escapes should not be detected", result.isEmpty())
+  }
+
+  fun testParserHandlesEscapedBackslashBeforeApostrophe() {
+    // \\\' = escaped backslash + literal apostrophe (not an escape)
+    val result = ComposeResourceEscapeInspection.findUnnecessaryEscapes("\\\\'")
+    assertTrue("\\\\' should not flag the apostrophe", result.isEmpty())
+  }
+
+  fun testParserHandlesTextWithNoEscapes() {
+    val result = ComposeResourceEscapeInspection.findUnnecessaryEscapes("Hello world")
+    assertTrue(result.isEmpty())
+  }
+
+  fun testParserHandlesEmptyString() {
+    val result = ComposeResourceEscapeInspection.findUnnecessaryEscapes("")
+    assertTrue(result.isEmpty())
+  }
+}

--- a/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceFormatInspectionTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceFormatInspectionTest.kt
@@ -1,0 +1,386 @@
+package dev.jordond.composeresourceskit.inspection
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class ComposeResourceFormatInspectionTest : BasePlatformTestCase() {
+  override fun setUp() {
+    super.setUp()
+    myFixture.enableInspections(ComposeResourceFormatInspection())
+  }
+
+  private fun addComposeResource(
+    path: String,
+    content: String,
+  ) {
+    myFixture.addFileToProject("composeResources/$path", content)
+  }
+
+  fun testValidPositionalSpecifiers() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="greeting">Hello %1${'$'}s, you have %2${'$'}d items</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("format specifier") == true ||
+        it.description?.contains("Format specifier") == true
+    }
+
+    assertTrue("Valid specifiers should not be flagged", formatErrors.isEmpty())
+  }
+
+  fun testNoSpecifiers() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="plain">Hello world</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("format specifier") == true ||
+        it.description?.contains("Format specifier") == true
+    }
+
+    assertTrue("Plain string should not be flagged", formatErrors.isEmpty())
+  }
+
+  fun testUnpositionedPercentS() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="bad">Hello %s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true
+    }
+
+    assertFalse("Unpositioned %s should be flagged", formatErrors.isEmpty())
+  }
+
+  fun testUnsupportedPercentF() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="bad_float">Value: %1${'$'}f</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true
+    }
+
+    assertFalse("Unsupported %1\$f should be flagged", formatErrors.isEmpty())
+  }
+
+  fun testNonSequentialNumbering() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="gap">%1${'$'}s and %3${'$'}s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val gapWarnings = highlights.filter {
+      it.description?.contains("not sequential") == true
+    }
+
+    assertFalse("Non-sequential numbering should be flagged", gapWarnings.isEmpty())
+  }
+
+  fun testConsistentPlurals() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <plurals name="items">
+              <item quantity="one">%1${'$'}d item</item>
+              <item quantity="other">%1${'$'}d items</item>
+          </plurals>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val consistencyWarnings = highlights.filter {
+      it.description?.contains("Plural variant") == true
+    }
+
+    assertTrue("Consistent plurals should not be flagged", consistencyWarnings.isEmpty())
+  }
+
+  fun testInconsistentPlurals() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <plurals name="items">
+              <item quantity="one">%1${'$'}d item</item>
+              <item quantity="other">%1${'$'}d items by %2${'$'}s</item>
+          </plurals>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val consistencyWarnings = highlights.filter {
+      it.description?.contains("Plural variant") == true
+    }
+
+    assertFalse("Inconsistent plural variants should be flagged", consistencyWarnings.isEmpty())
+  }
+
+  fun testIgnoresXmlOutsideComposeResources() {
+    myFixture.addFileToProject(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="bad">Hello %s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true
+    }
+
+    assertTrue("Should not inspect XML outside composeResources", formatErrors.isEmpty())
+  }
+
+  fun testQuickFixConvertsUnpositionedSpecifier() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="fix_me">Hello %s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    myFixture.doHighlighting()
+
+    val quickFix = myFixture.getAllQuickFixes().firstOrNull {
+      it.text.contains("Convert") && it.text.contains("positional")
+    }
+    assertNotNull("Expected quick fix to convert specifier", quickFix)
+    myFixture.launchAction(quickFix!!)
+
+    val text = myFixture.editor.document.text
+    assertTrue("Should contain positional specifier", text.contains("%1\$s"))
+    assertFalse("Should not contain unpositioned specifier", Regex("""(?<![\d$])%s""").containsMatchIn(text))
+  }
+
+  fun testEscapedPercentNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="percent">100%% complete</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true
+    }
+
+    assertTrue("Escaped %% should not be flagged", formatErrors.isEmpty())
+  }
+
+  fun testDollarAmountNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="price">Price: ${'$'}10.00</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true ||
+        it.description?.contains("Format specifier") == true
+    }
+
+    assertTrue("Dollar amount should not be flagged", formatErrors.isEmpty())
+  }
+
+  fun testTrailingPercentNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="pct">100%</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true ||
+        it.description?.contains("Format specifier") == true
+    }
+
+    assertTrue("Trailing % without a letter should not be flagged", formatErrors.isEmpty())
+  }
+
+  fun testPercentSpaceWordNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="sale">50% off</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true ||
+        it.description?.contains("Format specifier") == true
+    }
+
+    assertTrue("Percent followed by space then word should not be flagged", formatErrors.isEmpty())
+  }
+
+  fun testEscapedPercentImmediatelyFollowedByTextNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="compact">50%%off</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true
+    }
+
+    assertTrue("Escaped %% immediately followed by text should not be flagged", formatErrors.isEmpty())
+  }
+
+  fun testMixedDollarEscapedPercentAndValidSpecifier() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="complex">100%% of ${'$'}50 spent on %1${'$'}s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true
+    }
+
+    assertTrue("Mixed content with valid specifier should not produce false positives", formatErrors.isEmpty())
+  }
+
+  fun testPercentInParenthesesNotFlagged() {
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="paren">(50%) discount</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    val file = myFixture.findFileInTempDir("composeResources/values/strings.xml")!!
+    myFixture.configureFromExistingVirtualFile(file)
+
+    val highlights = myFixture.doHighlighting()
+    val formatErrors = highlights.filter {
+      it.description?.contains("Invalid format specifier") == true ||
+        it.description?.contains("Format specifier") == true
+    }
+
+    assertTrue("Percent inside parentheses should not be flagged", formatErrors.isEmpty())
+  }
+}

--- a/src/test/kotlin/dev/jordond/composeresourceskit/inspection/FormatSpecifierParserTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/inspection/FormatSpecifierParserTest.kt
@@ -40,8 +40,6 @@ class FormatSpecifierParserTest : TestCase() {
     assertEquals(3, FormatSpecifierParser.countFormatArguments("%1\$s %3\$s"))
   }
 
-  // -- validate --
-
   fun testValidStringPasses() {
     val issues = FormatSpecifierParser.validate("Hello %1\$s, you have %2\$d items")
     assertTrue(issues.isEmpty())
@@ -79,8 +77,6 @@ class FormatSpecifierParserTest : TestCase() {
     val invalidSpecifiers = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
     assertTrue("Escaped %% should not be flagged", invalidSpecifiers.isEmpty())
   }
-
-  // -- Percent and dollar sign edge cases --
 
   fun testDollarAmountNotFlagged() {
     val issues = FormatSpecifierParser.validate("Price: \$10.00")
@@ -172,8 +168,6 @@ class FormatSpecifierParserTest : TestCase() {
     val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
     assertTrue("Percent followed by ) should not be flagged", invalid.isEmpty())
   }
-
-  // -- validatePluralsConsistency --
 
   fun testConsistentPlurals() {
     val variants = mapOf(

--- a/src/test/kotlin/dev/jordond/composeresourceskit/inspection/FormatSpecifierParserTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/inspection/FormatSpecifierParserTest.kt
@@ -1,0 +1,206 @@
+package dev.jordond.composeresourceskit.inspection
+
+import junit.framework.TestCase
+
+class FormatSpecifierParserTest : TestCase() {
+  fun testExtractsValidSpecifiers() {
+    val specifiers = FormatSpecifierParser.extractSpecifiers("Hello %1\$s, you have %2\$d items")
+    assertEquals(2, specifiers.size)
+    assertEquals(1, specifiers[0].position)
+    assertEquals('s', specifiers[0].type)
+    assertEquals(2, specifiers[1].position)
+    assertEquals('d', specifiers[1].type)
+  }
+
+  fun testNoSpecifiers() {
+    val specifiers = FormatSpecifierParser.extractSpecifiers("Hello world")
+    assertTrue(specifiers.isEmpty())
+  }
+
+  fun testDoesNotExtractInvalidSpecifiers() {
+    val specifiers = FormatSpecifierParser.extractSpecifiers("Hello %s, value %f")
+    assertTrue("Unpositioned specifiers should not be extracted", specifiers.isEmpty())
+  }
+
+  fun testCountsDistinctPositions() {
+    assertEquals(2, FormatSpecifierParser.countFormatArguments("Hello %1\$s, you have %2\$d items"))
+  }
+
+  fun testCountsReusedPositions() {
+    // Same position used twice should still count as 1 argument
+    assertEquals(1, FormatSpecifierParser.countFormatArguments("%1\$s and %1\$s again"))
+  }
+
+  fun testCountsZeroForNoSpecifiers() {
+    assertEquals(0, FormatSpecifierParser.countFormatArguments("Hello world"))
+  }
+
+  fun testCountsMaxPosition() {
+    // %3$s means 3 arguments are needed (positions 1, 2, 3)
+    assertEquals(3, FormatSpecifierParser.countFormatArguments("%1\$s %3\$s"))
+  }
+
+  // -- validate --
+
+  fun testValidStringPasses() {
+    val issues = FormatSpecifierParser.validate("Hello %1\$s, you have %2\$d items")
+    assertTrue(issues.isEmpty())
+  }
+
+  fun testDetectsUnpositionedPercentS() {
+    val issues = FormatSpecifierParser.validate("Hello %s")
+    val invalidSpecifiers = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertEquals(1, invalidSpecifiers.size)
+    assertEquals("%s", invalidSpecifiers[0].specifier)
+  }
+
+  fun testDetectsUnsupportedPercentF() {
+    val issues = FormatSpecifierParser.validate("Value: %1\$f")
+    val invalidSpecifiers = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertEquals(1, invalidSpecifiers.size)
+  }
+
+  fun testDetectsNonSequentialNumbering() {
+    val issues = FormatSpecifierParser.validate("%1\$s and %3\$s")
+    val gapIssues = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.NonSequentialNumbering>()
+    assertEquals(1, gapIssues.size)
+    assertEquals(listOf(1, 2, 3), gapIssues[0].expected)
+    assertEquals(listOf(1, 3), gapIssues[0].actual)
+  }
+
+  fun testSequentialNumberingPasses() {
+    val issues = FormatSpecifierParser.validate("%1\$s and %2\$s")
+    val gapIssues = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.NonSequentialNumbering>()
+    assertTrue(gapIssues.isEmpty())
+  }
+
+  fun testEscapedPercentNotFlagged() {
+    val issues = FormatSpecifierParser.validate("100%% complete")
+    val invalidSpecifiers = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Escaped %% should not be flagged", invalidSpecifiers.isEmpty())
+  }
+
+  // -- Percent and dollar sign edge cases --
+
+  fun testDollarAmountNotFlagged() {
+    val issues = FormatSpecifierParser.validate("Price: \$10.00")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Dollar amount should not be flagged", invalid.isEmpty())
+  }
+
+  fun testDollarPrefixNotFlagged() {
+    val issues = FormatSpecifierParser.validate("\$variable_name")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Dollar prefix should not be flagged", invalid.isEmpty())
+  }
+
+  fun testTrailingPercentNotFlagged() {
+    val issues = FormatSpecifierParser.validate("100%")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Trailing percent with no letter after should not be flagged", invalid.isEmpty())
+  }
+
+  fun testPercentSpaceWordNotFlagged() {
+    val issues = FormatSpecifierParser.validate("50% off")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Percent followed by space then word should not be flagged", invalid.isEmpty())
+  }
+
+  fun testEscapedPercentFollowedByTextNotFlagged() {
+    val issues = FormatSpecifierParser.validate("50%%off")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Escaped %% immediately followed by text should not be flagged", invalid.isEmpty())
+  }
+
+  fun testMixedDollarAndEscapedPercentNotFlagged() {
+    val issues = FormatSpecifierParser.validate("Save \$5 (50%% off)")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Mixed dollar and escaped percent should not be flagged", invalid.isEmpty())
+  }
+
+  fun testDollarBeforeValidSpecifierNotFlagged() {
+    val issues = FormatSpecifierParser.validate("\$%1\$s")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Dollar before valid specifier should not produce extra errors", invalid.isEmpty())
+  }
+
+  fun testDollarAfterValidSpecifierNotFlagged() {
+    val issues = FormatSpecifierParser.validate("Price is %1\$s\$")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Dollar after valid specifier should not be flagged", invalid.isEmpty())
+  }
+
+  fun testMixedEverythingWithValidSpecifier() {
+    val issues = FormatSpecifierParser.validate("100%% of \$50 spent on %1\$s")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Mixed content with valid specifier should not produce false positives", invalid.isEmpty())
+  }
+
+  fun testPercentDollarLetterFlagged() {
+    val issues = FormatSpecifierParser.validate("%\$s")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertFalse("Malformed %\$s should be flagged as invalid", invalid.isEmpty())
+  }
+
+  fun testPercentImmediatelyFollowedByWordFlagged() {
+    val issues = FormatSpecifierParser.validate("50%off")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertFalse("Percent immediately followed by word should be flagged", invalid.isEmpty())
+  }
+
+  fun testTriplePercentThenText() {
+    // %%% = escaped %% then lone %, the lone % + text could match
+    val issues = FormatSpecifierParser.validate("%%%s")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertFalse("Third percent in %%%s should be flagged as unpositioned %s", invalid.isEmpty())
+  }
+
+  fun testLonePercentNotFlagged() {
+    val issues = FormatSpecifierParser.validate("%")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Lone percent at end of string should not be flagged", invalid.isEmpty())
+  }
+
+  fun testLoneDollarNotFlagged() {
+    val issues = FormatSpecifierParser.validate("\$")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Lone dollar sign should not be flagged", invalid.isEmpty())
+  }
+
+  fun testPercentInParenthesesNotFlagged() {
+    val issues = FormatSpecifierParser.validate("(50%) discount")
+    val invalid = issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InvalidSpecifier>()
+    assertTrue("Percent followed by ) should not be flagged", invalid.isEmpty())
+  }
+
+  // -- validatePluralsConsistency --
+
+  fun testConsistentPlurals() {
+    val variants = mapOf(
+      "one" to "%1\$d item",
+      "other" to "%1\$d items",
+    )
+    val issues = FormatSpecifierParser.validatePluralsConsistency(variants)
+    assertTrue(issues.isEmpty())
+  }
+
+  fun testInconsistentPlurals() {
+    val variants = mapOf(
+      "one" to "%1\$d item",
+      "other" to "%1\$d items by %2\$s",
+    )
+    val issues = FormatSpecifierParser.validatePluralsConsistency(variants)
+    val inconsistencies =
+      issues.filterIsInstance<FormatSpecifierParser.ValidationResult.InconsistentPluralsSpecifiers>()
+    assertEquals(1, inconsistencies.size)
+    assertEquals("one", inconsistencies[0].variant)
+    assertEquals(1, inconsistencies[0].variantCount)
+    assertEquals(2, inconsistencies[0].expectedCount)
+  }
+
+  fun testSingleVariantSkipsConsistencyCheck() {
+    val variants = mapOf("other" to "%1\$d items")
+    val issues = FormatSpecifierParser.validatePluralsConsistency(variants)
+    assertTrue(issues.isEmpty())
+  }
+}

--- a/src/test/kotlin/dev/jordond/composeresourceskit/inspection/UnusedComposeResourceInspectionTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/inspection/UnusedComposeResourceInspectionTest.kt
@@ -15,8 +15,6 @@ class UnusedComposeResourceInspectionTest : BasePlatformTestCase() {
     myFixture.addFileToProject("composeResources/$path", content)
   }
 
-  // -- Unused detection --
-
   fun testUnusedStringHighlighted() {
     addComposeResource(
       "values/strings.xml",
@@ -173,8 +171,6 @@ class UnusedComposeResourceInspectionTest : BasePlatformTestCase() {
     assertTrue("Should not flag used plurals", unusedWarnings.isEmpty())
   }
 
-  // -- Ignores non-compose resources --
-
   fun testIgnoresXmlOutsideComposeResources() {
     myFixture.addFileToProject(
       "values/strings.xml",
@@ -196,8 +192,6 @@ class UnusedComposeResourceInspectionTest : BasePlatformTestCase() {
 
     assertTrue("Should not inspect XML outside composeResources", unusedWarnings.isEmpty())
   }
-
-  // -- Mixed used/unused --
 
   fun testMixedUsedAndUnusedResources() {
     addComposeResource(
@@ -278,8 +272,6 @@ class UnusedComposeResourceInspectionTest : BasePlatformTestCase() {
     val homeWarning = unusedWarnings.find { it.description!!.contains("'home'") }
     assertNotNull("Resource 'home' should be flagged as unused even if 'home_action' is used", homeWarning)
   }
-
-  // -- Quick fix --
 
   fun testQuickFixRemovesTag() {
     addComposeResource(


### PR DESCRIPTION
This PR adds some more inspections to strings and plurals:

- `ComposeResourceFormatInspection`: Ensure that string arguments are defined correctly in XML files
- `ComposeResourceArgumentInspection`: Show a warning in Kotlin code if a resource has arguments but aren't passed in
- `[ComposeResourceEscapeInspection`: Report any escape characters that are used (not needed in Compose Multiplatform)