### PR TITLE
fix: resolve plugin verification compatibility failure

### DIFF
--- a/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspection.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspection.kt
@@ -36,6 +36,10 @@ class ComposeResourceArgumentInspection : LocalInspectionTool() {
         val calleeText = expression.calleeExpression?.text ?: return
         if (calleeText !in TARGET_FUNCTIONS) return
 
+        // Skip calls with an explicit receiver (e.g., receiver.stringResource(...))
+        val parent = expression.parent
+        if (parent is KtDotQualifiedExpression && parent.selectorExpression == expression) return
+
         // Quick PSI-level check: does the first argument look like a resource reference?
         val args = expression.valueArguments
         if (args.isEmpty()) return

--- a/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspection.kt
+++ b/src/main/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspection.kt
@@ -6,9 +6,6 @@ import com.intellij.psi.PsiElementVisitor
 import dev.jordond.composeresourceskit.RESOURCE_PREFIXES
 import dev.jordond.composeresourceskit.ResourceReference
 import dev.jordond.composeresourceskit.ResourceResolver
-import org.jetbrains.kotlin.analysis.api.analyze
-import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
-import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtVisitorVoid
@@ -85,29 +82,25 @@ class ComposeResourceArgumentInspection : LocalInspectionTool() {
   }
 
   /**
-   * Uses K2 Analysis API to resolve the call and confirm it targets
-   * a Compose Resources function (`stringResource` or `pluralStringResource`).
+   * Checks file imports to confirm the call targets a Compose Resources function.
    *
    * Returns the [FunctionKind] if confirmed, null otherwise.
    */
   private fun resolveFunction(expression: KtCallExpression): FunctionKind? {
-    return try {
-      analyze(expression) {
-        val call = expression
-          .resolveToCall()
-          ?.successfulFunctionCallOrNull() ?: return@analyze null
+    val calleeText = expression.calleeExpression?.text ?: return null
+    val kind = TARGET_FUNCTIONS[calleeText] ?: return null
 
-        val symbol = call.partiallyAppliedSymbol.symbol
-        val callableId = symbol.callableId ?: return@analyze null
-
-        if (callableId.className != null) return@analyze null
-        if (callableId.packageName.asString() != COMPOSE_RESOURCES_PACKAGE) return@analyze null
-
-        TARGET_FUNCTIONS[callableId.callableName.asString()]
+    val file = expression.containingKtFile
+    val hasMatchingImport = file.importDirectives.any { import ->
+      val fqName = import.importedFqName?.asString() ?: return@any false
+      if (import.isAllUnder) {
+        fqName == COMPOSE_RESOURCES_PACKAGE
+      } else {
+        fqName == "$COMPOSE_RESOURCES_PACKAGE.$calleeText"
       }
-    } catch (_: Exception) {
-      null
     }
+
+    return if (hasMatchingImport) kind else null
   }
 
   private fun extractResourceRef(expression: org.jetbrains.kotlin.psi.KtExpression): ResourceReference? {

--- a/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspectionTest.kt
+++ b/src/test/kotlin/dev/jordond/composeresourceskit/inspection/ComposeResourceArgumentInspectionTest.kt
@@ -301,6 +301,73 @@ class ComposeResourceArgumentInspectionTest : BasePlatformTestCase() {
     )
   }
 
+  fun testStringResourceWithWildcardImport() {
+    addResStub(strings = listOf("one_arg"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="one_arg">Hello %1${'$'}s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.*
+
+      fun test() {
+          stringResource(Res.string.one_arg)
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertFalse("Wildcard import should be recognized — 1 arg needed, 0 passed", argMismatches.isEmpty())
+  }
+
+  fun testIgnoresReceiverQualifiedCall() {
+    addResStub(strings = listOf("one_arg"))
+    addComposeResource(
+      "values/strings.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+          <string name="one_arg">Hello %1${'$'}s</string>
+      </resources>
+      """.trimIndent(),
+    )
+
+    myFixture.configureByText(
+      "Test.kt",
+      """
+      import org.jetbrains.compose.resources.stringResource
+
+      class MyHelper {
+          fun stringResource(resource: Any): String = ""
+      }
+
+      fun test() {
+          val helper = MyHelper()
+          helper.stringResource(Res.string.one_arg)
+      }
+      """.trimIndent(),
+    )
+
+    val highlights = myFixture.doHighlighting()
+    val argMismatches = highlights.filter {
+      it.description?.contains("format argument") == true
+    }
+
+    assertTrue("Receiver-qualified calls should be ignored", argMismatches.isEmpty())
+  }
+
   fun testIgnoresNonResourceCalls() {
     myFixture.configureByText(
       "Test.kt",


### PR DESCRIPTION
## Problem

`./gradlew verifyPlugin` fails with a compatibility problem on IntelliJ 2024.3 (IU-243) and 2025.1 (IU-251):

```
Method ComposeResourceArgumentInspection.resolveFunction() contains an
*invokevirtual* instruction referencing an unresolved method
KaSessionProvider.handleAnalysisException(). This can lead to
NoSuchMethodError at runtime.
```

The root cause is that `analyze {}` from the Kotlin Analysis API is an **inline function** — its bytecode gets embedded directly into our compiled class. That bytecode references `KaSessionProvider.handleAnalysisException()`, a method that was added in a newer version of the Kotlin plugin and does not exist in the Kotlin plugin bundled with IntelliJ 2024.3 or 2025.1.

Since the reference is baked into bytecode at compile time, no amount of runtime try-catch can prevent the verifier from flagging it as a compatibility problem.

### Verification results before fix

| IDE Version | Build | Result |
|---|---|---|
| IntelliJ 2024.3 | IU-243 | **1 compatibility problem** |
| IntelliJ 2025.1 | IU-251 | **1 compatibility problem** |
| IntelliJ 2025.2 | IU-252 | Compatible |
| IntelliJ 2025.3 | IU-253 | Compatible |
| IntelliJ 2026.1 | IU-261 | Compatible |

## Solution

Replace the K2 Analysis API `analyze {}` block in `ComposeResourceArgumentInspection.resolveFunction()` with a PSI-based import check. Instead of resolving the function symbol through the Analysis API, we now check whether the containing Kotlin file imports `stringResource` / `pluralStringResource` from `org.jetbrains.compose.resources` (including wildcard imports).

This is functionally equivalent for all practical usage patterns and has zero version-dependent API surface.

### Verification results after fix

| IDE Version | Build | Result |
|---|---|---|
| IntelliJ 2024.3 | IU-243 | **Compatible** |
| IntelliJ 2025.1 | IU-251 | **Compatible** |
| IntelliJ 2025.2 | IU-252 | **Compatible** |
| IntelliJ 2025.3 | IU-253 | **Compatible** |
| IntelliJ 2026.1 | IU-261 | **Compatible** |

## Test plan

- [x] All 118 existing tests pass
- [x] `./gradlew verifyPlugin` passes across all 5 IDE versions
- [x] `sinceBuild` remains at `243` — no loss of backward compatibility